### PR TITLE
Add foreign key constraint to table creation procedure.

### DIFF
--- a/general_process.cc
+++ b/general_process.cc
@@ -544,7 +544,7 @@ bool compare_output(vector<vector<vector<string>>>& a_output,
     return true;
 }
 
-int generate_database(dbms_info& d_info)
+int generate_database(dbms_info& d_info, int t_num)
 {
     if (remove(DB_RECORD_FILE) != 0) {
         cerr << "generate_database: cannot remove file (" << DB_RECORD_FILE << ")" << endl;
@@ -552,7 +552,7 @@ int generate_database(dbms_info& d_info)
 
     dut_reset(d_info);
 
-    auto ddl_stmt_num = d6() + 3; // at least 3 statements to create 3 tables
+    auto ddl_stmt_num = (t_num > 0) ? t_num : d6() + 3; // at least 3 statements to create 3 tables
     for (auto i = 0; i < ddl_stmt_num; i++)
         interect_test(d_info, &ddl_statement_factory, false, DB_RECORD_FILE); // has disabled the not null, check and unique clause
 

--- a/general_process.hh
+++ b/general_process.hh
@@ -104,7 +104,7 @@ void dut_reset_to_backup(dbms_info& d_info);
 void dut_get_content(dbms_info& d_info, 
                     map<string, vector<vector<string>>>& content);
 
-int generate_database(dbms_info& d_info);
+int generate_database(dbms_info& d_info, int t_num);
 
 string print_stmt_to_string(shared_ptr<prod> stmt);
 

--- a/grammar.hh
+++ b/grammar.hh
@@ -408,6 +408,7 @@ struct create_table_stmt: prod {
     bool has_engine = false;
     string table_engine;
     bool has_primary_key = false;
+    bool has_foreign_key = false;
     int primary_col_id;
     virtual void out(std::ostream &out);
     create_table_stmt(prod *parent, struct scope *s);

--- a/postgres.cc
+++ b/postgres.cc
@@ -211,8 +211,8 @@ schema_pqxx::schema_pqxx(string db, unsigned int port, string path, bool no_cata
     PQclear(res);
 
     // address the schema change in postgresql 11 that replaced proisagg and proiswindow with prokind
-    string procedure_is_aggregate = version_num < 110000 ? "proisagg" : "prokind = 'a'";
-    string procedure_is_window = version_num < 110000 ? "proiswindow" : "prokind = 'w'";
+    string procedure_is_aggregate = "prokind = 'a'";
+    string procedure_is_window = "prokind = 'w'";
 
     // cerr << "Loading types...";
     if (has_types == false) {
@@ -299,39 +299,42 @@ schema_pqxx::schema_pqxx(string db, unsigned int port, string path, bool no_cata
     supported_setting["enable_sort"] = vector<string>({"on", "off"});
     supported_setting["enable_tidscan"] = vector<string>({"on", "off"});
 
-    // Planner Cost Constants
-    // supported_setting["seq_page_cost"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
-    // supported_setting["random_page_cost "] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
-    // supported_setting["cpu_tuple_cost"] = vector<string>({"0", "0.001", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000"});
-    // supported_setting["cpu_index_tuple_cost"] = vector<string>({"0", "0.0005", "0.005", "0.05", "0.5", "5", "50", "500", "5000", "50000", "500000"});
-    // supported_setting["cpu_operator_cost"] = vector<string>({"0", "0.00025", "0.0025", "0.025", "0.25", "2.5", "25", "250", "2500", "25000", "250000"});
-    // supported_setting["parallel_setup_cost"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
-    // supported_setting["parallel_tuple_cost"] = vector<string>({"0", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000"});
-    // supported_setting["min_parallel_table_scan_size"] = vector<string>({"0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "715827882"});
-    // supported_setting["min_parallel_index_scan_size"] = vector<string>({"0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "715827882"});
-    // supported_setting["effective_cache_size"] = vector<string>({"1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000", "2147483647"});
-    // supported_setting["jit_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
-    // supported_setting["jit_inline_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
-    // supported_setting["jit_optimize_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
+#ifdef USE_PLANNER_PROP
+    supported_setting["seq_page_cost"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["random_page_cost "] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["cpu_tuple_cost"] = vector<string>({"0", "0.001", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000"});
+    supported_setting["cpu_index_tuple_cost"] = vector<string>({"0", "0.0005", "0.005", "0.05", "0.5", "5", "50", "500", "5000", "50000", "500000"});
+    supported_setting["cpu_operator_cost"] = vector<string>({"0", "0.00025", "0.0025", "0.025", "0.25", "2.5", "25", "250", "2500", "25000", "250000"});
+    supported_setting["parallel_setup_cost"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["parallel_tuple_cost"] = vector<string>({"0", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000"});
+    supported_setting["min_parallel_table_scan_size"] = vector<string>({"0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "715827882"});
+    supported_setting["min_parallel_index_scan_size"] = vector<string>({"0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "715827882"});
+    supported_setting["effective_cache_size"] = vector<string>({"1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000", "2147483647"});
+    supported_setting["jit_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
+    supported_setting["jit_inline_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
+    supported_setting["jit_optimize_above_cost"] = vector<string>({"-1", "0", "1", "10", "100", "1000", "10000", "100000", "1000000", "10000000", "100000000", "1000000000"});
+    supported_setting["default_statistics_target"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "10000"});
+    supported_setting["cursor_tuple_fraction"] = vector<string>({"0.0", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0"});
+    supported_setting["from_collapse_limit"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["join_collapse_limit"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["recursive_worktable_factor"] = vector<string>({"0.001", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000"});
+#endif
 
     // Genetic Query Optimizer
     supported_setting["geqo"] = vector<string>({"on", "off"});
-    // supported_setting["geqo_threshold"] = vector<string>({"2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
-    // supported_setting["geqo_effort"] = vector<string>({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"});
-    // supported_setting["geqo_pool_size"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
-    // supported_setting["geqo_generations"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128"});
-    // supported_setting["geqo_selection_bias"] = vector<string>({"1.50", "1.60", "1.70", "1.80", "1.90", "2.00"});
-    // supported_setting["geqo_seed"] = vector<string>({"0.0", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0"});
+#ifdef USE_GEQO_PROP
+    supported_setting["geqo_threshold"] = vector<string>({"2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["geqo_effort"] = vector<string>({"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"});
+    supported_setting["geqo_pool_size"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
+    supported_setting["geqo_generations"] = vector<string>({"0", "1", "2", "4", "8", "16", "32", "64", "128"});
+    supported_setting["geqo_selection_bias"] = vector<string>({"1.50", "1.60", "1.70", "1.80", "1.90", "2.00"});
+    supported_setting["geqo_seed"] = vector<string>({"0.0", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0"});
+#endif
 
     // Other Planner Options
-    // supported_setting["default_statistics_target"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "10000"});
     supported_setting["constraint_exclusion"] = vector<string>({"on", "off", "partition"});
-    // supported_setting["cursor_tuple_fraction"] = vector<string>({"0.0", "0.1", "0.2", "0.3", "0.4", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0"});
-    // supported_setting["from_collapse_limit"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
     supported_setting["jit"] = vector<string>({"on", "off"});
-    // supported_setting["join_collapse_limit"] = vector<string>({"1", "2", "4", "8", "16", "32", "64", "128", "256", "512", "1024", "2048", "4096", "8192", "2147483647"});
     supported_setting["plan_cache_mode"] = vector<string>({"auto", "force_custom_plan", "force_generic_plan"});
-    // supported_setting["recursive_worktable_factor"] = vector<string>({"0.001", "0.01", "0.1", "1", "10", "100", "1000", "10000", "100000", "1000000"});
 
     target_dbms = "postgres";
 

--- a/qcn.cc
+++ b/qcn.cc
@@ -184,7 +184,7 @@ int main(int argc, char *argv[]) {
     // analyze the options
     map<string,string> options;
     regex optregex("--\
-(help|db-test-num|seed|cpu-affinity|\
+(help|db-test-num|db-table-num|seed|cpu-affinity|\
 ignore-crash|\
 sqlite|\
 postgres-db|postgres-port|postgres-path|\
@@ -232,6 +232,7 @@ oceanbase-db|oceanbase-port|oceanbase-host)(?:=((?:.|\n)*))?");
         "    --yugabyte-port=int        YugaByte server port number" << endl <<
         "    --yugabyte-host=constr     YugaByte server host address" << endl <<
         "    --db-test-num=int      number of qcn tests for each generated database" << endl <<
+        "    --db-table-num=int      number of tables for each generated database" << endl <<
         "    --seed=int             seed RNG with specified int instead of PID" << endl <<
         "    --cpu-affinity=int     set cpu affinity of qcn and its child process to specific CPU" << endl <<
         "    --ignore-crash         ignore crash bug, the fuzzer will not stop when it finds crash issues" << endl <<
@@ -251,6 +252,10 @@ oceanbase-db|oceanbase-port|oceanbase-host)(?:=((?:.|\n)*))?");
     int db_test_time = DEFAULT_DB_TEST_TIME;
     if (options.count("db-test-num") > 0)
         db_test_time = stoi(options["db-test-num"]);
+
+    int table_num = 0;
+    if (options.count("db-table-num") > 0)
+        table_num = stoi(options["db-table-num"]);
 
     cpu_affinity = -1;
     if (options.count("cpu-affinity") > 0)
@@ -289,7 +294,7 @@ oceanbase-db|oceanbase-port|oceanbase-host)(?:=((?:.|\n)*))?");
             // fork_if_server_closed(d_info);
             while (true) {
                 try {
-                    generate_database(d_info);
+                    generate_database(d_info, table_num);
                     break;
                 } catch (exception &e) { // if fails, just try again
                     string err = e.what();


### PR DESCRIPTION
Add db-table-num option for create fixed ddl statements.
Remove the check of PostgreSQL versions 11 and below, as they are no longer supported.

A little code refactoring for supported settings.